### PR TITLE
Canonicalize '.', add require.cache

### DIFF
--- a/ctx-module.js
+++ b/ctx-module.js
@@ -123,6 +123,7 @@ function CtxModule(ctx, cnId, moduleCache, parent)
 
   /* Decorate new module's require with API properties */
   this.require.id = cnId;
+  this.require.cache = moduleCache;
   this.require.resolve = requireResolve;
   if (parent && parent.require)
   {
@@ -140,7 +141,7 @@ function CtxModule(ctx, cnId, moduleCache, parent)
    */
   function canonicalize(moduleIdentifier)
   {
-    if (moduleIdentifier.startsWith('./') || moduleIdentifier.startsWith('../'))
+    if (moduleIdentifier.startsWith('./') || moduleIdentifier.startsWith('../') || moduleIdentifier === '.')
       moduleIdentifier = relativeResolve(that.path, moduleIdentifier);
     else
       moduleIdentifier = relativeResolve(moduleIdentifier);


### PR DESCRIPTION
A path of `'.'` to load a module at the current directory is broken, can call `relativeResolve` to resolve the path to the correct directory.

Node's require has a `.cache` property that was missing from the ctx, add it to be a reference to `moduleCache`.