### PR TITLE
Only add module to cache if successfully loaded and fix when 'MODULE_NOT_FOUND' code is thrown 

### DIFF
--- a/ctx-module.js
+++ b/ctx-module.js
@@ -304,7 +304,18 @@ function CtxModule(ctx, cnId, moduleCache, parent)
     const loader = that.require.extensions[ext] || that.require.extensions['.js'];
 
     debug('ctx-module:load')(loader.name, filename);
-    loader(module, filename);
+
+    try 
+    {
+      loader(module, filename);
+    } 
+    catch (error) 
+    {
+      debugger
+      delete moduleCache[filename];
+      throw error;
+    }
+
     module.loaded = true;
     return module;
   }

--- a/ctx-module.js
+++ b/ctx-module.js
@@ -115,7 +115,7 @@ function CtxModule(ctx, cnId, moduleCache, parent)
     }
     catch(error)
     {
-      if (!error.code || error.code === 'ENOENT')
+      if (error.code === 'ENOENT')
         error.code = 'MODULE_NOT_FOUND';
       throw error;
     }
@@ -311,7 +311,6 @@ function CtxModule(ctx, cnId, moduleCache, parent)
     } 
     catch (error) 
     {
-      debugger
       delete moduleCache[filename];
       throw error;
     }

--- a/tests/bad-module-require.simple
+++ b/tests/bad-module-require.simple
@@ -8,8 +8,7 @@
  */
  'use strict';
 
- const vm = require('vm');
- const assert = require('assert');
+const vm = require('vm');
 const ctx = require('../ctx-module').makeNodeProgramContext();
 
 try
@@ -28,5 +27,5 @@ try
 }
 catch(error)
 {
-  assert(error.code === 'MODULE_NOT_FOUND');
+  console.log('test passed');
 }

--- a/tests/bad-module-require.simple
+++ b/tests/bad-module-require.simple
@@ -1,0 +1,32 @@
+#! /usr/bin/env node
+/**
+ * @file     bad-module-require.simple
+ *           Test to ensure that requiring a module that throws an error cannot be properly required again.
+ *
+ * @author   Robert Mirandola, <robert@distributive.network>
+ * @date     July 2023
+ */
+ 'use strict';
+
+ const vm = require('vm');
+ const assert = require('assert');
+const ctx = require('../ctx-module').makeNodeProgramContext();
+
+try
+{
+  vm.runInContext('require("./lib/bad-mod")', ctx);
+  console.error('Module should have thrown an error');
+  process.exit(1);
+}
+catch(e){}
+
+try
+{
+  vm.runInContext('require("./lib/bad-mod")', ctx);
+  console.error('Module was saved to moduleCache even though the module was not successfully loaded.');
+  process.exit(2);
+}
+catch(error)
+{
+  assert(error.code === 'MODULE_NOT_FOUND');
+}

--- a/tests/lib/bad-mod.js
+++ b/tests/lib/bad-mod.js
@@ -1,0 +1,3 @@
+exports.foo = 'bar';
+
+throw new Error();

--- a/tests/require-error.simple
+++ b/tests/require-error.simple
@@ -28,7 +28,7 @@ catch(error)
 try
 {
   vm.runInContext('require("bad-path")', ctx);
-  console.error('Module should have been found');
+  console.error('Module should not have been found.');
   process.exit(2);
 }
 catch(error)

--- a/tests/require-error.simple
+++ b/tests/require-error.simple
@@ -1,0 +1,38 @@
+#! /usr/bin/env node
+/**
+ * @file     require-error.simple
+ *           Test to ensure that requiring a module that throws an error does not return an error
+ *           code. Also ensures that requiring a module that does not exist throws an error with code
+ *           'MODULE_NOT_FOUND'.
+ *
+ * @author   Robert Mirandola, <robert@distributive.network>
+ * @date     July 2023
+ */
+ 'use strict';
+
+const vm = require('vm');
+const assert = require('assert');
+const ctx = require('../ctx-module').makeNodeProgramContext();
+
+try
+{
+  vm.runInContext('require("./lib/bad-mod")', ctx);
+  console.error('Module did not throw an error.');
+  process.exit(1);
+}
+catch(error)
+{
+  assert(!error.code, `Error has error code ${error.code}`);
+}
+
+try
+{
+  vm.runInContext('require("bad-path")', ctx);
+  console.error('Module should have been found');
+  process.exit(2);
+}
+catch(error)
+{
+  assert(error?.code === 'MODULE_NOT_FOUND', `Module threw a different error: ${error}`);
+  console.log('test passed');
+}


### PR DESCRIPTION
This PR fixes 2 things.

1. Let's say a module has bad code that throws an error. If you were to require that module a second time, the module would not throw the error but successfully grab the `module.exports`. This did not match the node `require` behaviour, so the module is only saved to cache when it is successfully loaded.
2. The error code `MODULE_NOT_FOUND` was thrown if there was no error code. That meant that if you tried to require a module that threw an error, that code would throw which is an incorrect explanation of what the error actually is. The change involves only throwing that error code if we see an `ENOENT` error when trying  to load the module.