### PR TITLE
Fix module cache, add a few properties expected on modules

### DIFF
--- a/ctx-module.js
+++ b/ctx-module.js
@@ -64,6 +64,7 @@ function CtxModule(ctx, cnId, moduleCache, parent)
       },
     };
   }
+  this.parent = parent;
 
   if (cnId) /* false => completely virtual exports-only module, via Module.from */
   {
@@ -373,6 +374,7 @@ function CtxModule(ctx, cnId, moduleCache, parent)
   /* Create the exports for the module module; it is special because it needs access to our internals. */
   if (cnId === 'module')
   {
+    this.exports.builtinModules = [];
     this.exports._nodeModulePaths = makeNodeModulesPaths;
     
     /* Create a _cache property which looks like Node's, and intercept mutations
@@ -382,7 +384,7 @@ function CtxModule(ctx, cnId, moduleCache, parent)
       get (_moduleCache, moduleIdentifier) {
         const retval = (true
                         && typeof moduleCache.hasOwnProperty(moduleIdentifier)
-                        && moduleCache[moduleIdentifier] === 'object')
+                        && typeof moduleCache[moduleIdentifier] === 'object')
               ? moduleCache[moduleIdentifier]
               : undefined;
         return retval;


### PR DESCRIPTION
Few small fixes to the module. Getting items from the cache needs to check the typeof the object in the module cache, not if it's literally 'object', and add a few properties expected on modules.