### PR TITLE
Windows Support in ctx-module

### DIFF
--- a/ctx-module.js
+++ b/ctx-module.js
@@ -90,7 +90,7 @@ function CtxModule(ctx, cnId, moduleCache, parent)
       return paths;
     
     /* Create a new modules.path for node_modules resolution */
-    for (let path = fromPath; path && path[0] === '/'; path = dirname(path))
+    for (let path = fromPath; path && (path[0] === '/' || path.match(/^[a-zA-Z]:[\/\\]/)); path = dirname(path))
     {
       if (path.endsWith('/node_modules'))
         continue;
@@ -105,6 +105,7 @@ function CtxModule(ctx, cnId, moduleCache, parent)
   /** Implementation of require() for this module */
   this.require = function ctxRequire(moduleIdentifier)
   {
+    moduleIdentifier = backToForward(moduleIdentifier);
     debug('ctx-module:require')('require ' + moduleIdentifier);
 
     try
@@ -182,7 +183,7 @@ function CtxModule(ctx, cnId, moduleCache, parent)
     if (pathname.startsWith('/'))
       newPath[0] = '';
     
-    components = pathname.split('/');
+    components = pathSplit(pathname);
     for (let i=0; i < components.length; i++)
     {
       let component = components[i];      
@@ -548,6 +549,22 @@ function copyProps(dst, src)
   const pds = Object.getOwnPropertyDescriptors(src);
   Object.defineProperties(dst, pds);
   return dst;
+}
+
+/**
+ * Splits Windows and Posix paths the same
+ */
+function pathSplit(path)
+{
+  return backToForward(path).split('/');
+}
+
+/**
+ * Converts backslashes to forward slashes
+ */
+function backToForward(path)
+{
+  return path.replace(/\\/g, '/');
 }
 
 exports.CtxModule = CtxModule;

--- a/ctx-module.js
+++ b/ctx-module.js
@@ -105,7 +105,7 @@ function CtxModule(ctx, cnId, moduleCache, parent)
   /** Implementation of require() for this module */
   this.require = function ctxRequire(moduleIdentifier)
   {
-    moduleIdentifier = backToForward(moduleIdentifier);
+    moduleIdentifier = moduleIdentifier.replace(/\\/g, '/');
     debug('ctx-module:require')('require ' + moduleIdentifier);
 
     try
@@ -183,7 +183,7 @@ function CtxModule(ctx, cnId, moduleCache, parent)
     if (pathname.startsWith('/'))
       newPath[0] = '';
     
-    components = pathSplit(pathname);
+    components = pathname.replace(/\\/g, '/').split('/');
     for (let i=0; i < components.length; i++)
     {
       let component = components[i];      
@@ -549,22 +549,6 @@ function copyProps(dst, src)
   const pds = Object.getOwnPropertyDescriptors(src);
   Object.defineProperties(dst, pds);
   return dst;
-}
-
-/**
- * Splits Windows and Posix paths the same
- */
-function pathSplit(path)
-{
-  return backToForward(path).split('/');
-}
-
-/**
- * Converts backslashes to forward slashes
- */
-function backToForward(path)
-{
-  return path.replace(/\\/g, '/');
 }
 
 exports.CtxModule = CtxModule;

--- a/ctx-module.js
+++ b/ctx-module.js
@@ -217,7 +217,7 @@ function CtxModule(ctx, cnId, moduleCache, parent)
       return moduleIdentifier;
     }
     
-    if (moduleIdentifier[0] === '/' || moduleIdentifier.match(/^[A-Z]:[\/\\]/)) // absolute paths
+    if (moduleIdentifier[0] === '/' || moduleIdentifier.match(/^[a-zA-Z]:[\/\\]/)) // absolute paths
       moduleFilename = locateModuleFile(relativeResolve(moduleIdentifier));
     else
     {

--- a/windows-tests/helloWorld.js
+++ b/windows-tests/helloWorld.js
@@ -1,0 +1,1 @@
+exports.hello = 'world';

--- a/windows-tests/windows-paths-smoke-test.simple
+++ b/windows-tests/windows-paths-smoke-test.simple
@@ -1,0 +1,35 @@
+'use strict';
+/**
+ * @file     windows-paths-smoke-test.simple
+ *           Test if ctx-module operates properly with Windows paths.
+ *
+ * @author   Will Pringle <will@distributive.network>
+ * @date     March 2024
+ */
+const assert = require('assert').strict;
+const vm = require('vm');
+const ctx = require('..\\ctx-module').makeNodeProgramContext();
+const ctxRequire = vm.runInContext('require', ctx);
+
+// full windows path
+const helloWorld = ctxRequire(__dirname + '\\helloWorld.js');
+assert(helloWorld.hello, 'world');
+
+// lets change it to 'earth' and see if further requires grab the right module
+helloWorld.hello = 'earth';
+
+// unix relative path 
+const helloWorld2 = ctxRequire('./helloWorld');
+assert(helloWorld2.hello, 'earth');
+
+// unix relative path with ..
+const helloWorld3 = ctxRequire('../windows-tests/helloWorld.js');
+assert(helloWorld3.hello, 'earth');
+
+// full windows path with ..
+const helloWorld4 = ctxRequire(__dirname + '\\..\\windows-tests\\helloWorld');
+assert(helloWorld4.hello, 'earth');
+
+// check that it hasn't somehow polluted nodejs require
+const helloWorld5 = require('./helloWorld');
+assert(helloWorld5.hello, 'world');


### PR DESCRIPTION
Well it turns out ctx-module is a lot closer to supporting Windows paths than I realized! When checking for absolute paths, you already check if the path either starts in a `/` or a windows drive letter and colon in one part of the code! 

Summary of changes:
- Also checks for drive letters in lowercase as well
- builds node_modules paths in windows properly by copying the drive letter absolute path detecton to the makeNodeModulesPaths function logic
- in `require` and `relativeResolve`, I replace backslashes to forward slashes in paths passed

The test suite now passes 12/12 tests with the following changes on Windows (_before this PR, 0/12 passed on Windows_), and I am able to require Windows paths if required.

---

Setting this to draft for now since I need to confirm that this really is the correct change. I thought this would be a lot more work...



