### PR TITLE
Bugfix: Ignore non-configurable properties

### DIFF
--- a/ctx-module.js
+++ b/ctx-module.js
@@ -547,7 +547,7 @@ exports.makeNodeProgramContext = function makeNodeProgramContext(options)
 function copyProps(dst, src)
 {
   const pds = Object.getOwnPropertyDescriptors(src);
-  for (var propds in pds)
+  for (const propds in pds)
   {
     if (pds[propds].configurable)
       Object.defineProperty(dst, propds, pds[propds]);

--- a/ctx-module.js
+++ b/ctx-module.js
@@ -547,7 +547,11 @@ exports.makeNodeProgramContext = function makeNodeProgramContext(options)
 function copyProps(dst, src)
 {
   const pds = Object.getOwnPropertyDescriptors(src);
-  Object.defineProperties(dst, pds);
+  for (var propds in pds)
+  {
+    if (pds[propds].configurable)
+      Object.defineProperty(dst, propds, pds[propds]);
+  }
   return dst;
 }
 


### PR DESCRIPTION
Note: `wtfnode` is the example here, but this seems to be a general issue with non-configurable properties.

`wtfnode` creates a property with `defineProperty`: `__callsite` that is not configurable. In `ctx-module` , we copy the exports with:
```
  const pds = Object.getOwnPropertyDescriptors(src);
  Object.defineProperties(dst, pds);
  return dst;
```
And this breaks when it sees the non configurable property, with a `TypeError` .  In this instance, I was simply running a unit test that uses `ctx-module` and was running it with `wtfnode`: `wtfnode unitTest.simple`. A workaround for this was to only copy over configurable properties.
```
  const pds = Object.getOwnPropertyDescriptors(src);
  for (var propds in pds)
    if (pds[propds].configurable)
      Object.defineProperty(dst, propds, pds[propds]);
  return dst;
```