### PR TITLE
fix(windows): make drive letter check case insensitive

### DIFF
--- a/ctx-module.js
+++ b/ctx-module.js
@@ -216,7 +216,7 @@ function CtxModule(ctx, cnId, moduleCache, parent)
       return moduleIdentifier;
     }
     
-    if (moduleIdentifier[0] === '/' || moduleIdentifier.match(/^[A-Z]:[\/\\]/)) // absolute paths
+    if (moduleIdentifier[0] === '/' || moduleIdentifier.match(/^[A-Za-z]:[\/\\]/)) // absolute paths
       moduleFilename = locateModuleFile(relativeResolve(moduleIdentifier));
     else
     {


### PR DESCRIPTION
Check for Windows drive letters only checked for CAPS but Windows fs is case insensitive

Thank you to jacalata https://github.com/Distributive-Network/PythonMonkey/issues/445