### PR TITLE
Overwrite module.exports when loading a json module

### DIFF
--- a/ctx-module.js
+++ b/ctx-module.js
@@ -296,7 +296,7 @@ function CtxModule(ctx, cnId, moduleCache, parent)
 
   function loadJSONModule(module, filename)
   {
-    copyProps(module.exports, JSON.parse(fs.readFileSync(filename, 'utf-8')));
+    module.exports = JSON.parse(fs.readFileSync(filename, 'utf-8'));
   }
 
   function loadModule(filename)


### PR DESCRIPTION
Suppose you try to `require('file.json')` where the contents of this file is simply `[1,2,3]`. The `copyProps` function will get the descriptors with object/value pairs of `{0: 1, 1: 2, 2: 3}` when it assigns everything to the exports object.

The purpose of that function was to support foreign modules with non-enumerable properties, but that can never happen when loading a json file, so we can just assign module.exports to the result of the json parse.


